### PR TITLE
Prevent ReferenceError in strict mode

### DIFF
--- a/blankshield.js
+++ b/blankshield.js
@@ -46,6 +46,8 @@
    * @param {string} [strWindowFeatures]
    */
   blankshield.open = function(strUrl, strWindowName) {
+    var child;
+    
     if (strWindowName && strWindowName !== '_blank') {
       open.apply(window, arguments);
     } else if (!oldIE) {


### PR DESCRIPTION
Currently `child` causes a ReferenceError.

Error occurred twice in production, UA details:  
Windows Phone 8.0
IE Mobile 10.0
