### PR TITLE
Respect windowFeatures with falsy windowName

### DIFF
--- a/blankshield.js
+++ b/blankshield.js
@@ -174,6 +174,8 @@
     openArgs = '"' + url + '"';
     if (strWindowName) {
       openArgs += ', "' + strWindowName + '"';
+    } else {
+      openArgs += ', ""';
     }
     if (strWindowFeatures) {
       openArgs += ', "' + strWindowFeatures + '"';


### PR DESCRIPTION
Currently, if you do `blankshield.open('url', '', 'width=100')` the `'width=100'` (and any other windowFeatures) is effectively ignored because they actually get passed to `window.open` as the second argument (windowName). This change always fills in a windowName argument, so that windowFeatures will always be correctly passed as the third argument.